### PR TITLE
Terraform backend S3 bucket region fix

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    region       = "ap-southeast-1"
+    region       = "us-east-1"
     bucket       = "vinod-terraform-test-bucket"
     key          = "merlion/dev/troubleshoot-terraform"
     use_lockfile = true


### PR DESCRIPTION
Changed the region of the S3 bucket used as the backend for Terraform from 'ap-southeast-1' to 'us-east-1' to match the actual location of the bucket.