### PR TITLE
Fixed AWS region mismatch issue in Terraform

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -14,5 +14,5 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-west-2"
+  region = "ap-southeast-1"
 }


### PR DESCRIPTION
The AWS region in the provider block was corrected to match the S3 bucket region, resolving the error when fetching workspaces.