### PR TITLE
Fix S3 bucket region

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    region       = "ap-southeast-1"
+    region       = "us-east-1"
     bucket       = "vinod-terraform-test-bucket"
     key          = "merlion/dev/troubleshoot-terraform"
     use_lockfile = true
@@ -12,7 +12,6 @@ terraform {
     }
   }
 }
-
 provider "aws" {
   region = "us-west-2"
 }


### PR DESCRIPTION
Changed S3 bucket region to us-east-1 to resolve 301 error. This will ensure that the S3 bucket and the Terraform configuration are in the same region.