### PR TITLE
Fix S3 backend region

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    region       = "ap-southeast-1"
+    region       = "us-east-1"
     bucket       = "vinod-terraform-test-bucket"
     key          = "merlion/dev/troubleshoot-terraform"
     use_lockfile = true


### PR DESCRIPTION
The S3 bucket 'vinod-terraform-test-bucket' is in the 'us-east-1' region, but the Terraform configuration was trying to access it using the 'ap-southeast-1' region. I changed the region value in the 'backend "s3"' block of 'init.tf' to match the actual location of the S3 bucket.