### PR TITLE
Fixed S3 backend region

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -1,15 +1,9 @@
 terraform {
   backend "s3" {
-    region       = "ap-southeast-1"
+    region       = "us-east-1"
     bucket       = "vinod-terraform-test-bucket"
     key          = "merlion/dev/troubleshoot-terraform"
     use_lockfile = true
-  }
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.99.1"
-    }
   }
 }
 


### PR DESCRIPTION
Changed the S3 backend region to us-east-1, as the S3 bucket is located in us-east-1 instead of ap-southeast-1. This change should resolve the issue with the S3 backend.