### PR TITLE
Update S3 bucket name to avoid conflict

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "example" {
-  bucket = "test"
+  bucket = "unique-test-bucket"
 
   tags = {
     Name        = "My bucket"

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,7 @@
 variable "environment" {
   description = "Required variable for isolating environments"
   default     = "dev"
+  lifecyle {
+    ignore_changes = true
+  }
 }


### PR DESCRIPTION
The S3 bucket with the name 'test' already exists, so we have changed the bucket name to 'unique-test-bucket' to avoid the conflict. We have also added a lifecycle block to the 'environment' variable to ignore changes to it.