### PR TITLE
Fix S3 bucket reference in outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
The reference to the aws_s3_bucket resource in outputs.tf has been corrected to remove the index key, as the resource does not have a count or for_each attribute set. This change ensures that the single instance of this resource can be properly referenced.