### PR TITLE
Fix: Removed unnecessary indexing from aws_s3_bucket resource reference.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
The aws_s3_bucket resource was being indexed with [0], but it is a single resource instance. This caused an error when trying to reference the bucket_domain_name attribute. I removed the indexing to correctly reference the single resource instance.

Root Cause Analysis:
The error message indicated that an unexpected resource instance key was encountered while referencing the `aws_s3_bucket` resource named `bucket_test`. This error occurred because the resource did not have a `count` or `for_each` attribute set, which means it is a single resource instance, and indexing it with `[0]` is not necessary or valid.

Step-by-Step Resolution:
1. Opened the `outputs.tf` file.
2. Removed the indexing `[0]` from the resource reference in the `s3_bucket_name` output: `output "s3_bucket_name" { value = aws_s3_bucket.bucket_test.bucket_domain_name }`.
3. Saved the changes to the `outputs.tf` file.