### PR TITLE
Fix: Output S3 bucket name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
The error 'Unexpected resource instance key' was caused by attempting to access an instance of a resource using an index key when the resource does not have a 'count' or 'for_each' attribute set. I removed the index key '0' from the resource reference in the 'outputs.tf' file, as the 'aws_s3_bucket.bucket_test' resource is not defined as a list or map. The updated 'outputs.tf' file now correctly references the 'bucket_domain_name' attribute of the 'aws_s3_bucket.bucket_test' resource without using an index key.