### PR TITLE
Fix: Updating the AWS S3 bucket region in Terraform configuration

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    region       = "us-east-1"
+    region       = "ap-southeast-1"
     bucket       = "vinod-terraform-test-bucket"
     key          = "merlion/dev/troubleshoot-terraform"
     use_lockfile = true
@@ -15,5 +15,5 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = "ap-southeast-1"
 }


### PR DESCRIPTION
This PR addresses the issue of a mismatched AWS S3 bucket region in the Terraform configuration. The error message indicated that the S3 bucket 'vinod-terraform-test-bucket' was located in the 'ap-southeast-1' region, while the Terraform configuration was set to use the 'us-east-1' region. By updating the 'region' value in the Terraform configuration to 'ap-southeast-1', we ensure that the region specified in the configuration matches the actual region of the S3 bucket, resolving the error and allowing Terraform to correctly interact with the S3 bucket. No changes were made to the 'main.tf', 'outputs.tf', or 'variables.tf' files, as the issue was specific to the 'init.tf' file.