### PR TITLE
Fix: Changed argument 'acls' to 'acl' in aws_s3_bucket resource.

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "bucket_test" {
-  bucket = "test-12121212121212121212121212121212"
-  acls   = "private"
+  bucket = "test-121212121212121212121212121212"
+acl = "private"
 }
 
 resource "aws_s3_bucket_versioning" "bucket_test" {


### PR DESCRIPTION
The argument 'acls' is not recognized by the resource 'aws_s3_bucket'. The correct argument is 'acl'. This error was resolved by changing 'acls' to 'acl' on line 3 of the file 's3.tf'. See the Step-by-Step Resolution for more details.