### PR TITLE
Fix: Replace 'acls' with 'acl' for aws_s3_bucket resource in s3.tf

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,8 +1,7 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls   = "private"
+acl = "private"
 }
-
 resource "aws_s3_bucket_versioning" "bucket_test" {
   bucket = aws_s3_bucket.bucket_test.bucket
 }


### PR DESCRIPTION
The error message indicated that an unsupported argument named 'acls' was used in the resource 'aws_s3_bucket' 'bucket_test'. The correct argument name for setting the ACL (Access Control List) for an S3 bucket is 'acl'. This issue likely occurred due to a typo or a misunderstanding of the correct argument name for this resource.

To resolve this issue, I followed these steps:
1. Opened the file 's3.tf' in a text editor.
2. Located the resource block for 'aws_s3_bucket' with the name 'bucket_test'.
3. Found the line where the argument 'acls' was used.
4. Replaced 'acls' with 'acl'.
5. Saved the changes to the file.

The modified file is as follows:
---
file: s3.tf
---
resource "aws_s3_bucket" "bucket_test" {
  bucket = "test-terraform-bucket-terraform-1234567890"
acl = "private"
}
resource "aws_s3_bucket_versioning" "bucket_test" {
  bucket = aws_s3_bucket.bucket_test.bucket
}
---