### PR TITLE
Corrected the argument name for the access control list of the S3 bucket.

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls   = "private"
+  acl = "private"
 }
 
 resource "aws_s3_bucket_versioning" "bucket_test" {


### PR DESCRIPTION
Based on the error message, it was identified that the argument name 'acls' for the access control list of the S3 bucket in 's3.tf' is incorrect. The correct argument name is 'acl'. This naming discrepancy caused the error.

Steps to Remediate:
1. Open the file 's3.tf' in a text editor.
2. Locate the line where the argument 'acls' is used.
3. Replace 'acls' with 'acl' on that line.
4. Save the changes to the file.
5. Retry running the Terraform plan or apply command to ensure the error is resolved.

Note: It is essential to verify the correct naming conventions and argument names when working with Terraform resources to avoid such errors. Refer to the Terraform documentation or provider-specific resources for accurate information on resource arguments.