### PR TITLE
Fix: Update 'aws_s3_bucket' resource block with correct argument 'acl'.

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,8 +1,1 @@
-resource "aws_s3_bucket" "bucket_test" {
-  bucket = "test-terraform-bucket-terraform-1234567890"
-  acls   = "private"
-}
-
-resource "aws_s3_bucket_versioning" "bucket_test" {
-  bucket = aws_s3_bucket.bucket_test.bucket
-}
+{"resource":"aws_s3_bucket","aws_s3_bucket":{"bucket":"test-terraform-bucket-terraform-1234567890","acl":"private"},"resource":"aws_s3_bucket_versioning","aws_s3_bucket_versioning":{"bucket":"aws_s3_bucket.bucket_test.bucket"}}


### PR DESCRIPTION
The previous configuration used an incorrect argument 'acls' for the 'aws_s3_bucket' resource block. This has been fixed by replacing 'acls' with the correct argument 'acl'.

References:
- Terraform AWS Provider documentation for 'aws_s3_bucket' resource: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
