### PR TITLE
Fix: Incorrect argument 'acls' in s3.tf, should be 'acl'

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls   = "private"
+  acl = "private"
 }
 
 resource "aws_s3_bucket_versioning" "bucket_test" {


### PR DESCRIPTION
Terraform was throwing an error due to an incorrect argument 'acls' in the s3.tf file. The correct argument for the ACL setting in an AWS S3 bucket resource block is 'acl'. I have corrected the argument name in the s3.tf file to resolve this issue.