### PR TITLE
Fix: Replaced 'acls' with 'acl' for aws_s3_bucket resource

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls   = "private"
+  acl = "private"
 }


### PR DESCRIPTION
This PR fixes the error by replacing 'acls' with the correct argument name 'acl' for the aws_s3_bucket resource in the s3.tf file.

Root Cause Analysis:
The error message suggests that an unsupported argument 'acls' was passed to the `aws_s3_bucket` resource. The correct argument name is 'acl'. This error is likely due to a misspelling or typo in the code.

Step-by-Step Resolution:
1. Open the `s3.tf` file.
2. Locate the line where the `aws_s3_bucket` resource is defined.
3. Check the argument named 'acls'.
4. Replace 'acls' with the correct argument name 'acl'.
5. Save the changes to the `s3.tf` file.
6. Run the `terraform init` command to initialize the Terraform working directory.
7. Run the `terraform validate` command to check if the configuration files are valid.
8. Run the `terraform plan` command to see the changes that will be made to the infrastructure.
9. If the changes are acceptable, run the `terraform apply` command to apply the changes.