### PR TITLE
Fix: Corrected argument name for 'aws_s3_bucket' resource block

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls   = "private"
+  acl = "private"
 }


### PR DESCRIPTION
An argument named 'acls' is not expected here. Did you mean 'acl'? To resolve this issue, we have corrected the argument name from 'acls' to 'acl' in the 'aws_s3_bucket' resource block in the 's3.tf' file. This change ensures that the Terraform configuration is valid and can be executed without any errors.