### PR TITLE
Fix: Unexpected resource instance key error in outputs.tf file

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
Root Cause Analysis:
The error message "Unexpected resource instance key" indicates that the Terraform code is trying to access a resource instance using an index key, but the resource does not have a count or for_each attribute set. This issue occurs in the outputs.tf file, where the aws_s3_bucket resource is being referenced with an index key [0] to access the bucket_domain_name attribute.

Step-by-Step Resolution:
To resolve this issue, follow these steps:
1. Open the outputs.tf file.
2. Locate the line where the aws_s3_bucket resource is being referenced with an index key.
3. Remove the index key [0] from the reference to the aws_s3_bucket resource.
4. Save the changes to the outputs.tf file.
5. Run the Terraform apply command again to apply the changes.