### PR TITLE
Fix: Resolved 'Unsupported argument' error in aws_s3_bucket resource block.

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls   = "private"
+  acl = "private"
 }


### PR DESCRIPTION
Root Cause Analysis:
The error message 'Unsupported argument' and the suggestion 'Did you mean 'acl'?' indicate that the issue is with the argument used in the resource block for the aws_s3_bucket resource in the s3.tf file. The argument 'acls' is not recognized, and it seems to be a typo for the valid argument 'acl'. The correct argument is 'acl', which stands for Access Control List and is used to set the access permissions for the S3 bucket.

Step-by-Step Resolution:
1. Open the s3.tf file in a text editor.
2. Locate the resource block for the aws_s3_bucket resource.
3. Look for the argument 'acls' in the resource block.
4. Replace the argument 'acls' with the correct argument 'acl'.
5. Save the changes to the s3.tf file.
6. Validate the changes by running the terraform validate command in the terminal.
7. If the validation is successful, proceed to run the terraform plan and terraform apply commands to apply the changes to the infrastructure.