### PR TITLE
Fix: Removed index key from aws_s3_bucket reference in outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
Error message: `Unexpected resource instance key`

Root Cause Analysis:
The error message is indicating that the Terraform code is attempting to access an index key on a resource that does not have a count or for_each attribute set. This is typically seen when trying to reference an instance of a resource that has not been defined as a list or map.

Step-by-Step Resolution:
1. Open the outputs.tf file.
2. Locate the output block that is causing the error.
3. Remove the index key from the reference to the aws_s3_bucket resource.
4. Save the changes to the outputs.tf file.
5. Run the Terraform plan command to check for any changes.
6. If there are no changes, run the Terraform apply command to apply the changes.
7. Verify that the error has been resolved by checking the output of the Terraform apply command.

Modified Files:
outputs.tf