### PR TITLE
Fix: Unsupported argument error in s3.tf file

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls = "private"
+  acl = "private"
 }


### PR DESCRIPTION
The issue was due to an incorrect argument name 'acls' used in the s3.tf file. It has been changed to the correct argument name 'acl'. This change ensures that the Terraform code for creating an S3 bucket works as expected.

Changes:
- s3.tf: Changed 'acls' to 'acl' in the aws_s3_bucket resource block.