### PR TITLE
Fix: Removed index key from aws_s3_bucket resource reference in outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
Error message: 'Unexpected resource instance key'

Root Cause Analysis:
The error message 'Unexpected resource instance key' implies that Terraform is expecting a single resource instance, but it encountered an index key, which is not allowed. In this case, the issue is with the `outputs.tf` file, where the `aws_s3_bucket` resource is being referenced with an index key `[0]`. Since the `aws_s3_bucket` resource does not have a `count` or `for_each` attribute, it is considered a single resource instance, and indexing it is not necessary.

Step-by-Step Resolution:
1. Open the `outputs.tf` file in a text editor.
2. Locate the line where the `aws_s3_bucket` resource is being referenced with an index key. It should look something like this:

    value = aws_s3_bucket.bucket_test[0].bucket_domain_name

3. Remove the index key `[0]` from the reference to the `aws_s3_bucket` resource. The line should now look like this:

    value = aws_s3_bucket.bucket_test.bucket_domain_name
4. Save the changes to the `outputs.tf` file.
5. Run the Terraform commands `terraform init`, `terraform validate`, `terraform plan`, and `terraform apply` again to verify that the error has been resolved.

Modified Files:
outputs.tf
---
output "s3_bucket_name" {
  value = aws_s3_bucket.bucket_test.bucket_domain_name
}

s3.tf
---
resource "aws_s3_bucket" "bucket_test" {
  bucket = "test-terraform-bucket-terraform-1234567890"
  acl = "private"
}