### PR TITLE
Fix: Argument 'acls' is not supported for 'aws_s3_bucket' resource

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls = "private"
+  acl = "private"
 }


### PR DESCRIPTION
The error message 'Unsupported argument' suggests that the Terraform code is attempting to use an argument that is not recognized by the resource being configured. In this case, the error is occurring in the 's3.tf' file on line 3, where the argument 'acls' is being used for the 'aws_s3_bucket' resource. The 'aws_s3_bucket' resource in Terraform does not have an argument named 'acls'. Instead, the correct argument to use for setting the access control list (ACL) for the S3 bucket is 'acl'. By following the steps outlined in the root cause analysis and step-by-step resolution, the error 'Unsupported argument' should be resolved, and the S3 bucket should be created with the correct ACL setting.