### PR TITLE
Fix: Update 'aws_s3_bucket' argument to 'acl'

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls    = "private"
+  acl    = "private"
 }


### PR DESCRIPTION
Error message: `Error: Unsupported argument

  on s3.tf line 12, in resource "aws_s3_bucket" "bucket_test":
  12:   acls    = "private"

An argument named "acls" is not expected here. Did you mean to define a block of type "acl"?`

Step-by-step resolution:
1. Open the 's3.tf' file in a text editor.
2. Locate the resource block for 'aws_s3_bucket' with the name 'bucket_test'.
3. Find the line that contains the argument 'acls' and replace it with the correct argument 'acl'.
4. Save the changes to the 's3.tf' file.
5. Verify that the corrected code is free from any other syntax errors.
6. Run the Terraform plan command to check for any changes that need to be applied.
7. If there are changes, run the Terraform apply command to apply the changes and create the S3 bucket with the desired ACL.