### PR TITLE
Fix: Remove unnecessary index key from resource reference

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }

--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acl    = "private"
+  acl = "private"
 }


### PR DESCRIPTION
The error message 'Unexpected resource instance key' indicates that the Terraform code is attempting to access an instance of a resource using an index key, but the resource in question does not have a 'count' or 'for_each' attribute set. In this case, the code is trying to access the 'bucket_domain_name' attribute of the 'aws_s3_bucket.bucket_test' resource using an index key of '[0]'. However, the 'aws_s3_bucket.bucket_test' resource does not have a 'count' or 'for_each' attribute set, which means it should only have one instance. Therefore, the index key is unnecessary and causing the error.

To fix the issue, the index key was removed from the resource reference in the 'outputs.tf' file.