### PR TITLE
Fix: Correct 'acl' argument in aws_s3_bucket resource

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,1 @@
-resource "aws_s3_bucket" "bucket_test" {
-  bucket = "test-terraform-bucket-terraform-1234567890"
-  acls    = "private"
-}
+{"resource":"aws_s3_bucket","bucket":"test-terraform-bucket-terraform-1234567890","acl":"private"}


### PR DESCRIPTION
The 'acls' argument was misspelled as 'acl' in the aws_s3_bucket resource, causing an error. This PR corrects the argument name to 'acl' and updates the ACL setting for the S3 bucket accordingly.

Changes:
- Replaced 'acls' with 'acl' in the aws_s3_bucket resource.