### PR TITLE
Fix: Incorrect syntax for aws_s3_bucket resource.

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,1 +1,1 @@
-{"resource":"aws_s3_bucket","bucket":"test-terraform-bucket-terraform-1234567890","acl":"private"}
+{"resource":"aws_s3_bucket","bucket_test":{"bucket":"test-terraform-bucket-terraform-1234567890","acl":"private"}}


### PR DESCRIPTION
The aws_s3_bucket resource was missing the required block definition. The issue has been resolved by adding the block definition and ensuring the correct syntax. This change will allow Terraform to correctly parse the configuration file and initialize the resources.