### PR TITLE
Fix: Update s3.tf for aws_s3_bucket resource

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,1 @@
-resource "aws_s3_bucket" "bucket_test" {
-  bucket = "test-terraform-bucket-terraform-1234567890"
-  acls   = "private"
-}
+{"resource":"aws_s3_bucket","bucket_test":{"bucket":"test-terraform-bucket-terraform-1234567890","acl":"private"}}


### PR DESCRIPTION
Changed 'acls' to 'acl' in s3.tf file for aws_s3_bucket resource. This change resolves the issue of 'Unsupported argument' and aligns with the expected argument for aws_s3_bucket resource.