### PR TITLE
Fix: Argument name mismatch for aws_s3_bucket resource.

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls    = "private"
+  acl = "private"
 }


### PR DESCRIPTION
Corrected the argument name 'acls' to 'acl' for the aws_s3_bucket resource in the s3.tf file.

Steps to Remediate:
1. Open the s3.tf file.
2. Locate the line with the 'acls' argument for the aws_s3_bucket resource.
3. Replace 'acls' with the correct argument name 'acl'.
4. Save the changes to the file.
5. Run 'terraform plan' to check for any changes.
6. If changes are detected, apply them using 'terraform apply'.
7. Verify the error is resolved by running 'terraform plan' and 'terraform apply' again.
8. If any further errors occur, review the Terraform documentation for the 'aws_s3_bucket' resource to ensure correct argument and configuration usage.