### PR TITLE
Fix: Remove unexpected index key from aws_s3_bucket reference

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
The error message "Unexpected resource instance key" was due to the reference to the aws_s3_bucket resource in the outputs.tf file. The resource "aws_s3_bucket.bucket_test" does not have a "count" or "for_each" set, which means it is a single resource instance. However, the reference to this resource included an index key "[0]", which is not expected for a single resource instance. I removed the index key "[0]" from the reference to the aws_s3_bucket resource to resolve this issue.