### PR TITLE
Fix: Replace 'acls' with 'acl' in aws_s3_bucket resource

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls = "private"
+  acl = "private"
 }


### PR DESCRIPTION
The 'acls' argument is not supported in the aws_s3_bucket resource. It has been replaced with 'acl' to set the access control list (ACL) of the S3 bucket. This change ensures that the Terraform configuration is using the correct argument for specifying the ACL of an S3 bucket.