### PR TITLE
Fix: Unexpected resource instance key error

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
We encountered an error message 'Unexpected resource instance key' in our Terraform configuration. After analyzing the issue, we found that the reference to the aws_s3_bucket resource in the outputs.tf file included an unnecessary index key [0]. We have removed the index key to resolve the issue.

Steps to Remediate:
1. Open the outputs.tf file.
2. Locate the line with the error message.
3. Remove the index key [0] from the reference to the aws_s3_bucket resource.
4. Save the changes to the outputs.tf file.
5. Run the Terraform plan command to check for any changes.
6. If there are changes, apply them using the Terraform apply command.