### PR TITLE
Fix: Correct argument 'acl' used for 'aws_s3_bucket' resource.

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls = "private"
+  acl = "private"
 }


### PR DESCRIPTION
The 'aws_s3_bucket' resource in the 's3.tf' file was using the incorrect argument 'acls' to set the access control policy for the S3 bucket. This has been changed to the correct argument 'acl'.

The correct argument 'acl' is used to set the access control policy for the S3 bucket, and the value 'private' is a valid option.

The changes have been tested in a non-production environment and have passed the 'terraform validate' command.