### PR TITLE
Fix: Unexpected resource instance key error

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
Removed the index key '[0]' from the reference to the 'aws_s3_bucket.bucket_test' resource in the 'outputs.tf' file, as it is not configured with a 'count' or 'for_each' attribute.