### PR TITLE
Fix: Argument 'acls' replaced with 'acl' in 'aws_s3_bucket' resource.

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls = "private"
+  acl = "private"
 }


### PR DESCRIPTION
The error message 'Unsupported argument' with a suggestion of 'Did you mean 'acl'?' indicates that the Terraform code is trying to use an argument that is not recognized by the 'aws_s3_bucket' resource. The argument 'acls' is not a valid argument for this resource, and the correct argument is 'acl'. This pull request fixes the issue by replacing 'acls' with 'acl' in the 'aws_s3_bucket' resource.