### PR TITLE
Fix: Removed index key from aws_s3_bucket.bucket_test reference in outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
Based on the error message 'Unexpected resource instance key', it was determined that the 'aws_s3_bucket.bucket_test' resource in the 'outputs.tf' file did not have a 'count' or 'for_each' attribute set, but an index key was being used. To resolve this, the index key was removed from the resource reference in the 'outputs.tf' file.

Steps to Remediate:
1. Open the 'outputs.tf' file in a text editor.
2. Locate the line that contains the error:
    output "s3_bucket_name" {
      value = aws_s3_bucket.bucket_test[0].bucket_domain_name
    }
3. Remove the index key '0' from the resource reference:
    output "s3_bucket_name" {
      value = aws_s3_bucket.bucket_test.bucket_domain_name
    }
4. Save the changes to the file.