### PR TITLE
Fix: Correct argument for AWS S3 bucket resource.

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acls = "private"
+  acl = "private"
 }


### PR DESCRIPTION
An unsupported argument 'acls' was used for the AWS S3 bucket resource in s3.tf. This caused an error when applying the Terraform configuration. To resolve this issue, the argument 'acls' was replaced with the correct argument 'acl'. The updated configuration ensures that the AWS S3 bucket is configured correctly.