### PR TITLE
Remove index key from aws_s3_bucket reference in outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
+terraform
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }

--- a/s3.tf
+++ b/s3.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "bucket_test" {
   bucket = "test-terraform-bucket-terraform-1234567890"
-  acl = "private"
+  acls = "private"
 }


### PR DESCRIPTION
The aws_s3_bucket resource is not being managed as a collection but is being treated as a collection in the outputs.tf file. To resolve this issue, the index key should be removed from the reference to the aws_s3_bucket resource in the outputs.tf file.