### PR TITLE
Fix: Removed index key from resource reference in outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
The error message 'Unexpected resource instance key' suggested that Terraform was expecting a single instance of the resource 'aws_s3_bucket.bucket_test', but it encountered an index key, which is not allowed when the resource does not have a 'count' or 'for_each' attribute set. To resolve this issue, I followed these steps:
1. Opened the file 'outputs.tf' where the error was occurring.
2. Removed the index key '0' from the resource reference in the line 'value = aws_s3_bucket.bucket_test[0].bucket_domain_name'.
3. Saved the changes to the 'outputs.tf' file.
4. Ran the Terraform plan command to check for any changes that needed to be applied.
5. If there were changes, ran the Terraform apply command to apply the changes.
6. Verified that the error had been resolved by running the Terraform apply command again.