### PR TITLE
Fix: Removed unnecessary index key for aws_s3_bucket resource in outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
Since the aws_s3_bucket resource in s3.tf does not have a count or for_each attribute set, it is expected to create only one instance of the resource. Therefore, there is no need to use an index key to access the instance in outputs.tf.

I followed these steps to fix the issue:
1. Removed the index key from the resource reference in outputs.tf.
2. Validated the changes using the 'terraform validate' command.
3. Applied the changes using the 'terraform apply' command.
