### PR TITLE
Fix: Unexpected resource instance key error in outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
+terraform
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
The error message "Unexpected resource instance key" implies that Terraform is encountering an issue when trying to access a resource instance using an index key. The problem is being triggered by the reference to aws_s3_bucket in the outputs.tf file. To resolve this issue, I modified the reference to the aws_s3_bucket resource in the outputs.tf file to remove the index key. This change will allow Terraform to correctly access the resource instance and prevent the error message from being displayed.