### PR TITLE
Fix: Remove unnecessary index key for aws_s3_bucket resource reference in outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,5 @@
+terraform
+
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
The index key [0] was causing an error when trying to access the bucket_domain_name attribute of the aws_s3_bucket resource with the name bucket_test. This is because the resource does not have a count or for_each attribute set, which means it is only being created once. When accessing a resource that is only being created once, the index key is not necessary and can cause an error.

I have removed the index key from the reference to the aws_s3_bucket resource in outputs.tf, which should resolve the issue.

Files Modified:
- outputs.tf