### PR TITLE
Fix: Remove index key from output value for aws_s3_bucket resource.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
The error message 'Unexpected resource instance key' was encountered when trying to access the aws_s3_bucket resource using an index key. This issue has been resolved by removing the index key from the output value for the aws_s3_bucket resource in the outputs.tf file.

Steps to Remediate:
1. Identified the output value causing the error in the outputs.tf file.
2. Removed the index key ([0]) from the output value for the aws_s3_bucket resource.
3. Saved the changes to the outputs.tf file.
4. Ran the 'terraform apply' command to apply the changes.
5. Verified that the error has been resolved by checking the output of the 'terraform apply' command.