### PR TITLE
Fix: Removed unnecessary index key from aws_s3_bucket resource reference.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "s3_bucket_name" {
-  value = aws_s3_bucket.bucket_test[0].bucket_domain_name
+  value = aws_s3_bucket.bucket_test.bucket_domain_name
 }


### PR DESCRIPTION
The aws_s3_bucket resource in the s3.tf file does not have the count or for_each attributes set, so the index key [0] used when referencing the resource in the outputs.tf file is unnecessary and causing an error. I have removed the index key from the reference to resolve the issue.